### PR TITLE
numpy,taco: updates to windowing benchmarks, add a fusing benchmark

### DIFF
--- a/numpy/ufuncs.py
+++ b/numpy/ufuncs.py
@@ -3,7 +3,7 @@ from scipy.sparse import random, csr_matrix
 import sparse
 import pytest
 import os
-from util import TensorCollectionFROSTT, PydataTensorShifter, TensorCollectionSuiteSparse, ScipyTensorShifter, PydataMatrixMarketTensorLoader, ScipyMatrixMarketTensorLoader, VALIDATION_OUTPUT_PATH, PydataSparseTensorDumper, SuiteSparseTensor, safeCastPydataTensorToInts
+from util import TensorCollectionFROSTT, PydataTensorShifter, TensorCollectionSuiteSparse, ScipyTensorShifter, PydataMatrixMarketTensorLoader, ScipyMatrixMarketTensorLoader, VALIDATION_OUTPUT_PATH, PydataSparseTensorDumper, SuiteSparseTensor, safeCastPydataTensorToInts, RandomPydataSparseTensorLoader
 
 # TODO (rohany): Ask hameer about this. pydata/sparse isn't happy when
 #  given this ufunc to evaluate.
@@ -34,6 +34,16 @@ def bench_pydata_ufunc_sparse(tacoBench, dim, ufunc):
         C = ufunc(A, B)
     tacoBench(bench)
 
+@pytest.mark.parametrize("dim", [5000, 10000, 20000])
+def bench_pydata_ufunc_fused(tacoBench, dim):
+    loader = RandomPydataSparseTensorLoader()
+    matrix = safeCastPydataTensorToInts(loader.random((dim, dim), 0.01))
+    matrix1 = safeCastPydataTensorToInts(loader.random((dim, dim), 0.01, variant=1))
+    matrix2 = safeCastPydataTensorToInts(loader.random((dim, dim), 0.01, variant=2))
+    def bench():
+        result = numpy.logical_and(numpy.logical_xor(matrix, matrix1), matrix2)
+        return result
+    tacoBench(bench)
 
 def import_tensor(filename, dim):
     print(filename)

--- a/numpy/util.py
+++ b/numpy/util.py
@@ -92,10 +92,13 @@ class PydataSparseTensorDumper:
 # The key itself is formatted by the dimensions, followed by the
 # sparsity. For example, a 250 by 250 tensor with sparsity 0.01
 # would have a key of 250x250-0.01.tns.
-def construct_random_tensor_key(shape, sparsity):
+def construct_random_tensor_key(shape, sparsity, variant):
     path = TENSOR_PATH
     dims = "x".join([str(dim) for dim in shape])
-    key = "{}-{}.tns".format(dims, sparsity)
+    if variant is None:
+        key = "{}-{}.tns".format(dims, sparsity)
+    else:
+        key = "{}-{}-{}.tns".format(dims, sparsity, variant)
     return os.path.join(path, "random", key)
 
 # RandomPydataSparseTensorLoader should be used to generate
@@ -106,8 +109,8 @@ class RandomPydataSparseTensorLoader:
     def __init__(self):
         self.loader = PydataSparseTensorLoader()
 
-    def random(self, shape, sparsity):
-        key = construct_random_tensor_key(shape, sparsity)
+    def random(self, shape, sparsity, variant=None):
+        key = construct_random_tensor_key(shape, sparsity, variant)
         # If a tensor with these properties exists already, then load it.
         if os.path.exists(key):
             return self.loader.load(key)
@@ -126,9 +129,9 @@ class RandomScipySparseTensorLoader:
         self.loader = ScipySparseTensorLoader(format)
         self.format = format
 
-    def random(self, shape, sparsity):
+    def random(self, shape, sparsity, variant=None):
         assert(len(shape) == 2)
-        key = construct_random_tensor_key(shape, sparsity)
+        key = construct_random_tensor_key(shape, sparsity, variant)
         # If a tensor with these properties exists already, then load it.
         if os.path.exists(key):
             return self.loader.load(key)

--- a/numpy/windowing.py
+++ b/numpy/windowing.py
@@ -14,7 +14,6 @@ from util import RandomScipySparseTensorLoader, RandomPydataSparseTensorLoader
 sizeConfigs = ["Constant", "ConstantFraction", "AlmostWhole", "Whole", "NoWindowing"]
 
 def sliceTensor(tensor, dim, config):
-    return tensor
     if config == "Constant":
         return tensor[250:750, 250:750]
     elif config == "ConstantFraction":
@@ -36,9 +35,11 @@ def sliceTensor(tensor, dim, config):
 def bench_add_sparse_window(tacoBench, dim, format, config):
     loader = RandomScipySparseTensorLoader(format)
     matrix = loader.random((dim, dim), 0.01)
+    matrix2 = loader.random((dim, dim), 0.01, variant=1)
     def bench():
         x = sliceTensor(matrix, dim, config)
-        res = x + x
+        x2 = sliceTensor(matrix2, dim, config)
+        res = x + x2
         # Sanity check that this has a similar runtime as taco.
         # res = matrix + matrix
     tacoBench(bench)
@@ -50,12 +51,12 @@ def bench_add_sparse_window(tacoBench, dim, format, config):
 def bench_add_pydata_sparse_window(tacoBench, dim, config):
     loader = RandomPydataSparseTensorLoader()
     matrix = loader.random((dim, dim), 0.01)
+    matrix2 = loader.random((dim, dim), 0.01, variant=1)
     def bench():
         x = sliceTensor(matrix, dim, config)
-        res = x + x
+        x2 = sliceTensor(matrix2, dim, config)
+        res = x + x2
     tacoBench(bench)
-
-# TODO (rohany): Parametrize the below tests by appropriate windowing config.
 
 @pytest.mark.parametrize("dim", [5000, 10000, 20000])
 @pytest.mark.parametrize("format", ['csr', 'csc'])
@@ -63,9 +64,11 @@ def bench_add_pydata_sparse_window(tacoBench, dim, config):
 def bench_add_sparse_strided_window(tacoBench, dim, format, strideWidth):
     loader = RandomScipySparseTensorLoader(format)
     matrix = loader.random((dim, dim), 0.01)
+    matrix2 = loader.random((dim, dim), 0.01, variant=1)
     def bench():
         x = matrix[0:dim:strideWidth, 0:dim:strideWidth] 
-        res = x + x
+        x2 = matrix2[0:dim:strideWidth, 0:dim:strideWidth] 
+        res = x + x2
     tacoBench(bench)
 
 @pytest.mark.parametrize("dim", [5000, 10000, 20000])
@@ -75,9 +78,11 @@ def bench_add_sparse_index_set(tacoBench, dim, format, fraction):
     indexes = [i * fraction for i in range(0, dim//fraction)]
     loader = RandomScipySparseTensorLoader(format)
     matrix = loader.random((dim, dim), 0.01)
+    matrix2 = loader.random((dim, dim), 0.01, variant=1)
     def bench():
         x = matrix[:, indexes] 
-        res = x + x
+        x2 = matrix2[:, indexes] 
+        res = x + x2
     tacoBench(bench)
 
 @pytest.mark.parametrize("dim", [5000, 10000, 20000])
@@ -85,9 +90,11 @@ def bench_add_sparse_index_set(tacoBench, dim, format, fraction):
 def bench_add_pydata_sparse_strided_window(tacoBench, dim, strideWidth):
     loader = RandomPydataSparseTensorLoader()
     matrix = loader.random((dim, dim), 0.01)
+    matrix2 = loader.random((dim, dim), 0.01, variant=1)
     def bench():
         x = matrix[0:dim:strideWidth, 0:dim:strideWidth] 
-        res = x + x
+        x2 = matrix[0:dim:strideWidth, 0:dim:strideWidth] 
+        res = x + x2
     tacoBench(bench)
 
 # TODO (rohany): This is really slow (compared to scipy.sparse). Check with hameer
@@ -98,12 +105,13 @@ def bench_add_pydata_sparse_index_set(tacoBench, dim, fraction):
     loader = RandomPydataSparseTensorLoader()
     indexes = [i * fraction for i in range(0, dim//fraction)]
     matrix = loader.random((dim, dim), 0.01)
+    matrix2 = loader.random((dim, dim), 0.01, variant=1)
     def bench():
         x = matrix[:, indexes] 
-        res = x + x
+        x = matrix2[:, indexes] 
+        res = x + x2
     tacoBench(bench)
 
-# TODO (rohany): I don't know if we care about this benchmark.
 @pytest.mark.parametrize("dim", [5000, 10000, 20000])
 @pytest.mark.parametrize("format", ['csr', 'csc'])
 @pytest.mark.skip(reason="not using currently")

--- a/taco/bench.cpp
+++ b/taco/bench.cpp
@@ -38,7 +38,7 @@ std::string cleanPath(std::string path) {
   return result;
 }
 
-std::string constructRandomTensorKey(std::vector<int> dims, float sparsity) {
+std::string constructRandomTensorKey(std::vector<int> dims, float sparsity, int variant) {
   auto path = getTacoTensorPath();
   std::stringstream result;
   result << path;
@@ -46,14 +46,18 @@ std::string constructRandomTensorKey(std::vector<int> dims, float sparsity) {
     result << "/";
   }
   result << "random/";
-  result << taco::util::join(dims, "x") << "-" << sparsity << ".tns";
+  if (variant == 0) {
+    result << taco::util::join(dims, "x") << "-" << sparsity << ".tns";
+  } else {
+    result << taco::util::join(dims, "x") << "-" << sparsity << "-" << variant << ".tns";
+  }
   return result.str();
 }
 
-taco::TensorBase loadRandomTensor(std::string name, std::vector<int> dims, float sparsity, taco::Format format) {
+taco::TensorBase loadRandomTensor(std::string name, std::vector<int> dims, float sparsity, taco::Format format, int variant) {
   // For now, just say that the python code must generate the random
   // tensor before use.
-  auto tensor = taco::read(constructRandomTensorKey(dims, sparsity), format, true);
+  auto tensor = taco::read(constructRandomTensorKey(dims, sparsity, variant), format, true);
   tensor.setName(name);
   return tensor;
 }

--- a/taco/bench.h
+++ b/taco/bench.h
@@ -49,7 +49,7 @@ std::string getTacoTensorPath();
 std::string getValidationOutputPath();
 // cleanPath ensures that the input path ends with "/".
 std::string cleanPath(std::string path);
-taco::TensorBase loadRandomTensor(std::string name, std::vector<int> dims, float sparsity, taco::Format format);
+taco::TensorBase loadRandomTensor(std::string name, std::vector<int> dims, float sparsity, taco::Format format, int variant=0);
 
 template<typename T>
 taco::Tensor<T> castToType(std::string name, taco::Tensor<double> tensor) {


### PR DESCRIPTION
* Update the windowing benchmarks to use a different tensor as the
  operand, rather than the same tensor.
* Achieve the above point by allowing the random tensor caching
  mechanism to store variants of the same tensor
* Add a benchmark that fuses some ufuncs together for an interesting
  iteration space.